### PR TITLE
各関数のインターフェースをContextを渡せるように改修

### DIFF
--- a/application/address_scenario.go
+++ b/application/address_scenario.go
@@ -1,6 +1,8 @@
 package application
 
 import (
+	"context"
+
 	"github.com/nekochans/address-search-apis/domain"
 )
 
@@ -9,9 +11,10 @@ type AddressScenario struct {
 }
 
 type FindByPostalCodeRequest struct {
+	Ctx        context.Context
 	PostalCode string
 }
 
 func (s *AddressScenario) FindByPostalCode(req *FindByPostalCodeRequest) (*domain.Address, error) {
-	return s.AddressRepository.FindByPostalCode(req.PostalCode)
+	return s.AddressRepository.FindByPostalCode(req.Ctx, req.PostalCode)
 }

--- a/application/address_scenario_test.go
+++ b/application/address_scenario_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -91,7 +92,7 @@ func TestHandler(t *testing.T) {
 			AddressRepository: repo,
 		}
 
-		req := &FindByPostalCodeRequest{PostalCode: "1620062"}
+		req := &FindByPostalCodeRequest{Ctx: context.Background(), PostalCode: "1620062"}
 		res, err := scenario.FindByPostalCode(req)
 
 		if err != nil {
@@ -120,7 +121,7 @@ func TestHandler(t *testing.T) {
 			AddressRepository: repo,
 		}
 
-		req := &FindByPostalCodeRequest{PostalCode: "4040000"}
+		req := &FindByPostalCodeRequest{Ctx: context.Background(), PostalCode: "4040000"}
 		res, err := scenario.FindByPostalCode(req)
 
 		expected := "Address is not found"
@@ -146,7 +147,7 @@ func TestHandler(t *testing.T) {
 			AddressRepository: repo,
 		}
 
-		req := &FindByPostalCodeRequest{PostalCode: "1000000"}
+		req := &FindByPostalCodeRequest{Ctx: context.Background(), PostalCode: "1000000"}
 		res, err := scenario.FindByPostalCode(req)
 
 		expected := "Unexpected error"

--- a/application/address_scenario_test.go
+++ b/application/address_scenario_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nekochans/address-search-apis/infrastructure"
+
 	"github.com/nekochans/address-search-apis/domain"
 	"github.com/nekochans/address-search-apis/infrastructure/repository"
 )
@@ -92,7 +94,8 @@ func TestHandler(t *testing.T) {
 			AddressRepository: repo,
 		}
 
-		req := &FindByPostalCodeRequest{Ctx: context.Background(), PostalCode: "1620062"}
+		ctx := context.Background()
+		req := &FindByPostalCodeRequest{Ctx: infrastructure.CreateContextWithRequestId(ctx), PostalCode: "1620062"}
 		res, err := scenario.FindByPostalCode(req)
 
 		if err != nil {
@@ -121,7 +124,8 @@ func TestHandler(t *testing.T) {
 			AddressRepository: repo,
 		}
 
-		req := &FindByPostalCodeRequest{Ctx: context.Background(), PostalCode: "4040000"}
+		ctx := context.Background()
+		req := &FindByPostalCodeRequest{Ctx: infrastructure.CreateContextWithRequestId(ctx), PostalCode: "4040000"}
 		res, err := scenario.FindByPostalCode(req)
 
 		expected := "Address is not found"
@@ -147,7 +151,8 @@ func TestHandler(t *testing.T) {
 			AddressRepository: repo,
 		}
 
-		req := &FindByPostalCodeRequest{Ctx: context.Background(), PostalCode: "1000000"}
+		ctx := context.Background()
+		req := &FindByPostalCodeRequest{Ctx: infrastructure.CreateContextWithRequestId(ctx), PostalCode: "1000000"}
 		res, err := scenario.FindByPostalCode(req)
 
 		expected := "Unexpected error"

--- a/cmd/lambda/findbypostalcode/main.go
+++ b/cmd/lambda/findbypostalcode/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/nekochans/address-search-apis/infrastructure"
 	"net/http"
 	"time"
+
+	"github.com/nekochans/address-search-apis/infrastructure"
 
 	"github.com/nekochans/address-search-apis/domain"
 
@@ -60,7 +61,6 @@ func createErrorResponse(statusCode int, message string) events.APIGatewayV2HTTP
 
 func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 	newCtx := infrastructure.CreateContextWithRequestId(ctx)
-	infrastructure.ExtractRequestIdFromContext(newCtx)
 
 	if val, ok := req.PathParameters["postalCode"]; ok {
 		repo := &repository.KenallAddressRepository{HttpClient: client}
@@ -69,6 +69,7 @@ func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.AP
 		}
 
 		request := &application.FindByPostalCodeRequest{
+			Ctx:        newCtx,
 			PostalCode: val,
 		}
 

--- a/cmd/lambda/findbypostalcode/main.go
+++ b/cmd/lambda/findbypostalcode/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"github.com/nekochans/address-search-apis/infrastructure"
 	"net/http"
 	"time"
 
@@ -58,6 +59,9 @@ func createErrorResponse(statusCode int, message string) events.APIGatewayV2HTTP
 }
 
 func Handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	newCtx := infrastructure.CreateContextWithRequestId(ctx)
+	infrastructure.ExtractRequestIdFromContext(newCtx)
+
 	if val, ok := req.PathParameters["postalCode"]; ok {
 		repo := &repository.KenallAddressRepository{HttpClient: client}
 		scenario := &application.AddressScenario{

--- a/domain/address_repository.go
+++ b/domain/address_repository.go
@@ -1,9 +1,13 @@
 package domain
 
-import "github.com/pkg/errors"
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
 
 type AddressRepository interface {
-	FindByPostalCode(postalCode string) (*Address, error)
+	FindByPostalCode(ctx context.Context, postalCode string) (*Address, error)
 }
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/aws/aws-lambda-go v1.24.0
+	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/infrastructure/repository/kenall_address_repository.go
+++ b/infrastructure/repository/kenall_address_repository.go
@@ -50,8 +50,7 @@ type FindAddressesResponse struct {
 	Addresses []*Address `json:"data"`
 }
 
-func (r *KenallAddressRepository) FindByPostalCode(postalCode string) (*domain.Address, error) {
-	ctx := context.Background()
+func (r *KenallAddressRepository) FindByPostalCode(ctx context.Context, postalCode string) (*domain.Address, error) {
 	req, _ := http.NewRequestWithContext(ctx, "GET", "https://api.kenall.jp/v1/postalcode/"+postalCode, nil)
 	req.Header.Set("Authorization", "Token "+os.Getenv("KENALL_API_KEY"))
 

--- a/infrastructure/request.go
+++ b/infrastructure/request.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"context"
+
 	"github.com/aws/aws-lambda-go/lambdacontext"
 	"github.com/google/uuid"
 )

--- a/infrastructure/request.go
+++ b/infrastructure/request.go
@@ -1,0 +1,36 @@
+package infrastructure
+
+import (
+	"context"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+	"github.com/google/uuid"
+)
+
+type contextKey string
+
+const requestIdContextKey contextKey = "requestId"
+
+func CreateContextWithRequestId(ctx context.Context) context.Context {
+	newCtx := context.Background()
+
+	lc, ok := lambdacontext.FromContext(ctx)
+	if ok {
+		newCtx = context.WithValue(newCtx, requestIdContextKey, lc.AwsRequestID)
+	} else {
+		u, _ := uuid.NewRandom()
+		uu := u.String()
+		newCtx = context.WithValue(newCtx, requestIdContextKey, uu)
+	}
+
+	return newCtx
+}
+
+func ExtractRequestIdFromContext(ctx context.Context) string {
+	requestId, ok := ctx.Value(requestIdContextKey).(string)
+
+	if ok {
+		return requestId
+	}
+
+	return ""
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/address-search-apis/issues/13

# Doneの定義
- 各関数のインターフェースがcontextが受け取れるようになっている事

# 変更点概要
- 各関数をcontextを受け取れるように改修

# 補足情報
context にはAWS LambdaのリクエストIDを入れるようにした。

ロギング時にこのリクエストIDを利用する予定。