### PR TITLE
RequestIdをHTTPHeaderで渡せるように改修

### DIFF
--- a/application/address_scenario_test.go
+++ b/application/address_scenario_test.go
@@ -95,7 +95,10 @@ func TestHandler(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		req := &FindByPostalCodeRequest{Ctx: infrastructure.CreateContextWithRequestId(ctx), PostalCode: "1620062"}
+		req := &FindByPostalCodeRequest{
+			Ctx:        infrastructure.CreateContextWithRequestId(ctx, "aaaaaaaaaaaaa-bbbb-cccc-ddddddddddd1"),
+			PostalCode: "1620062",
+		}
 		res, err := scenario.FindByPostalCode(req)
 
 		if err != nil {
@@ -125,7 +128,11 @@ func TestHandler(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		req := &FindByPostalCodeRequest{Ctx: infrastructure.CreateContextWithRequestId(ctx), PostalCode: "4040000"}
+		req := &FindByPostalCodeRequest{Ctx: infrastructure.CreateContextWithRequestId(
+			ctx,
+			"aaaaaaaaaaaaa-bbbb-cccc-ddddddddddd1"),
+			PostalCode: "4040000",
+		}
 		res, err := scenario.FindByPostalCode(req)
 
 		expected := "Address is not found"
@@ -152,7 +159,10 @@ func TestHandler(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		req := &FindByPostalCodeRequest{Ctx: infrastructure.CreateContextWithRequestId(ctx), PostalCode: "1000000"}
+		req := &FindByPostalCodeRequest{
+			Ctx:        infrastructure.CreateContextWithRequestId(ctx, "aaaaaaaaaaaaa-bbbb-cccc-ddddddddddd1"),
+			PostalCode: "1000000",
+		}
 		res, err := scenario.FindByPostalCode(req)
 
 		expected := "Unexpected error"
@@ -183,7 +193,10 @@ func TestHandler(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		req := &FindByPostalCodeRequest{Ctx: infrastructure.CreateContextWithRequestId(ctx), PostalCode: "16200621"}
+		req := &FindByPostalCodeRequest{
+			Ctx:        infrastructure.CreateContextWithRequestId(ctx, "aaaaaaaaaaaaa-bbbb-cccc-ddddddddddd1"),
+			PostalCode: "16200621",
+		}
 		res, err := scenario.FindByPostalCode(req)
 
 		expected := "postalCode format is invalid"

--- a/infrastructure/logger.go
+++ b/infrastructure/logger.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Logger struct {
-	zapLogger *zap.Logger
-	requestId string
+	zapLogger       *zap.Logger
+	lambdaRequestId string
+	httpRequestId   string
 }
 
-func CreateLogger(requestId string) *Logger {
+func CreateLogger(lambdaReqId string, httpReqId string) *Logger {
 	level := zap.NewAtomicLevel()
 	level.SetLevel(zapcore.DebugLevel)
 
@@ -35,17 +36,26 @@ func CreateLogger(requestId string) *Logger {
 	zapLogger, _ := zapConfig.Build(zap.AddCallerSkip(1))
 
 	logger := &Logger{
-		zapLogger: zapLogger,
-		requestId: requestId,
+		zapLogger:       zapLogger,
+		lambdaRequestId: lambdaReqId,
+		httpRequestId:   httpReqId,
 	}
 
 	return logger
 }
 
 func (l *Logger) Info(msg string) {
-	l.zapLogger.Info(msg, zap.String("requestId", l.requestId))
+	l.zapLogger.Info(
+		msg,
+		zap.String("lambdaRequestId", l.lambdaRequestId),
+		zap.String("httpRequestId", l.httpRequestId),
+	)
 }
 
 func (l *Logger) Error(msg string) {
-	l.zapLogger.Error(msg, zap.String("requestId", l.requestId))
+	l.zapLogger.Error(
+		msg,
+		zap.String("lambdaRequestId", l.lambdaRequestId),
+		zap.String("httpRequestId", l.httpRequestId),
+	)
 }

--- a/infrastructure/request.go
+++ b/infrastructure/request.go
@@ -9,25 +9,47 @@ import (
 
 type contextKey string
 
-const requestIdContextKey contextKey = "requestId"
+const lambdaRequestIdContextKey contextKey = "lambdaRequestId"
 
-func CreateContextWithRequestId(ctx context.Context) context.Context {
+const httpRequestIdContextKey contextKey = "httpRequestId"
+
+func CreateContextWithRequestId(ctx context.Context, r string) context.Context {
 	newCtx := context.Background()
+
+	u, _ := uuid.NewRandom()
+
+	var httpReqId string
+	if r == "" {
+		httpReqId = u.String()
+	} else {
+		httpReqId = r
+	}
+
+	newCtx = context.WithValue(newCtx, httpRequestIdContextKey, httpReqId)
 
 	lc, ok := lambdacontext.FromContext(ctx)
 	if ok {
-		newCtx = context.WithValue(newCtx, requestIdContextKey, lc.AwsRequestID)
+		newCtx = context.WithValue(newCtx, lambdaRequestIdContextKey, lc.AwsRequestID)
 	} else {
-		u, _ := uuid.NewRandom()
 		uu := u.String()
-		newCtx = context.WithValue(newCtx, requestIdContextKey, uu)
+		newCtx = context.WithValue(newCtx, lambdaRequestIdContextKey, uu)
 	}
 
 	return newCtx
 }
 
-func ExtractRequestIdFromContext(ctx context.Context) string {
-	requestId, ok := ctx.Value(requestIdContextKey).(string)
+func ExtractLambdaRequestIdFromContext(ctx context.Context) string {
+	requestId, ok := ctx.Value(lambdaRequestIdContextKey).(string)
+
+	if ok {
+		return requestId
+	}
+
+	return ""
+}
+
+func ExtractHttpRequestIdFromContext(ctx context.Context) string {
+	requestId, ok := ctx.Value(httpRequestIdContextKey).(string)
 
 	if ok {
 		return requestId


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/address-search-apis/issues/19

# 関連URL
- `/v1/{postalCode}`

# Doneの定義
- リクエストヘッダーに `X-Request-Id` を指定出来るようになっている事
- ログ出力時にも `X-Request-Id` を出力するようになっている事

# 変更点概要
HTTPヘッダーで `X-Request-Id` を受け取り、レスポンスヘッダーに追加する対応を行った。

ロギングの際にも `X-Request-Id` を出力するように変更しました。

## infoログ

```
{
    "level": "INFO",
    "time": "2021-08-01T09:45:48.333Z",
    "caller": "command-line-arguments/main.go:118",
    "message": "{\"postalCode\":\"1620062\",\"prefecture\":\"東京都\",\"locality\":\"新宿区市谷加賀町\"}",
    "lambdaRequestId": "f2381a40-c09c-4762-a68f-344528cc294d",
    "httpRequestId": "zzzzzzzzzzzzz-zzzz-(=^・^=)-dddddddd"
}
```

## errorログ

```
{
    "level": "ERROR",
    "time": "2021-08-01T03:00:45.749Z",
    "caller": "command-line-arguments/main.go:91",
    "message": "postalCode format is invalid",
    "lambdaRequestId": "6da54cd3-13ae-4568-b139-9f858c45b9ae",
    "httpRequestId": "zzzzzzzzzzzzz-zzzz-(=^・^=)-dddddddd",
    "stackTrace": "main.Handler\n\tcommand-line-arguments/main.go:91\nreflect.Value.call\n\treflect/value.go:476\nreflect.Value.Call\n\treflect/value.go:337\ngithub.com/aws/aws-lambda-go/lambda.NewHandler.func1\n\tgithub.com/aws/aws-lambda-go@v1.24.0/lambda/handler.go:124\ngithub.com/aws/aws-lambda-go/lambda.lambdaHandler.Invoke\n\tgithub.com/aws/aws-lambda-go@v1.24.0/lambda/handler.go:24\ngithub.com/aws/aws-lambda-go/lambda.(*Function).Invoke\n\tgithub.com/aws/aws-lambda-go@v1.24.0/lambda/function.go:64\nreflect.Value.call\n\treflect/value.go:476\nreflect.Value.Call\n\treflect/value.go:337\nnet/rpc.(*service).call\n\tnet/rpc/server.go:377"
}
```