### PR TITLE
HTTPClientのMockを作成する関数を別のファイルに分離

### DIFF
--- a/application/address_scenario_test.go
+++ b/application/address_scenario_test.go
@@ -2,79 +2,20 @@ package application
 
 import (
 	"context"
-	"encoding/json"
-	"io"
-	"net/http"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 
-	"github.com/nekochans/address-search-apis/infrastructure"
-
 	"github.com/nekochans/address-search-apis/domain"
+	"github.com/nekochans/address-search-apis/infrastructure"
 	"github.com/nekochans/address-search-apis/infrastructure/repository"
+	"github.com/nekochans/address-search-apis/test"
 )
 
 func TestMain(m *testing.M) {
 	status := m.Run()
 
 	os.Exit(status)
-}
-
-type mockResponse struct {
-	Body       string
-	StatusCode int
-	Result     interface{}
-	Error      error
-}
-
-type successMockClient struct {
-	MockAddress *repository.Address
-}
-
-func (c *successMockClient) Do(req *http.Request) (*http.Response, error) {
-	mockResBodyData := []*repository.Address{c.MockAddress}
-
-	mockResBody := &repository.FindAddressesResponse{
-		Version:   "2021-06-30",
-		Addresses: mockResBodyData,
-	}
-
-	bodyJson, _ := json.Marshal(mockResBody)
-
-	mockRes := &mockResponse{
-		Body:       string(bodyJson),
-		StatusCode: http.StatusOK,
-		Result:     mockResBody,
-	}
-
-	return &http.Response{StatusCode: mockRes.StatusCode, Body: io.NopCloser(strings.NewReader(mockRes.Body))}, nil
-}
-
-func createSuccessMockClient(mockAddress *repository.Address) *successMockClient {
-	return &successMockClient{MockAddress: mockAddress}
-}
-
-type errorMockClient struct {
-	StatusCode  int
-	MockResBody interface{}
-}
-
-func (c *errorMockClient) Do(req *http.Request) (*http.Response, error) {
-	bodyJson, _ := json.Marshal(c.MockResBody)
-
-	mockRes := &mockResponse{
-		Body:       string(bodyJson),
-		StatusCode: c.StatusCode,
-		Result:     c.MockResBody,
-	}
-
-	return &http.Response{StatusCode: mockRes.StatusCode, Body: io.NopCloser(strings.NewReader(mockRes.Body))}, nil
-}
-
-func createErrorMockClient(statusCode int, mockResBody interface{}) *errorMockClient {
-	return &errorMockClient{StatusCode: statusCode, MockResBody: mockResBody}
 }
 
 // nolint:funlen
@@ -86,7 +27,7 @@ func TestHandler(t *testing.T) {
 			Town:       "市谷加賀町",
 		}
 
-		client := createSuccessMockClient(mockAddress)
+		client := test.CreateFindAddressesSuccessMockClient(mockAddress)
 
 		repo := &repository.KenallAddressRepository{HttpClient: client}
 
@@ -119,7 +60,7 @@ func TestHandler(t *testing.T) {
 	t.Run("Error FindByPostalCode Address is not found", func(t *testing.T) {
 		mockResBody := &repository.Address{}
 
-		client := createErrorMockClient(404, mockResBody)
+		client := test.CreateFindAddressesErrorMockClient(404, mockResBody)
 
 		repo := &repository.KenallAddressRepository{HttpClient: client}
 
@@ -150,7 +91,7 @@ func TestHandler(t *testing.T) {
 	t.Run("Error FindByPostalCode Unexpected error", func(t *testing.T) {
 		mockResBody := &repository.Address{}
 
-		client := createErrorMockClient(500, mockResBody)
+		client := test.CreateFindAddressesErrorMockClient(500, mockResBody)
 
 		repo := &repository.KenallAddressRepository{HttpClient: client}
 
@@ -184,7 +125,7 @@ func TestHandler(t *testing.T) {
 			Town:       "市谷加賀町",
 		}
 
-		client := createSuccessMockClient(mockAddress)
+		client := test.CreateFindAddressesSuccessMockClient(mockAddress)
 
 		repo := &repository.KenallAddressRepository{HttpClient: client}
 

--- a/test/find_addresses_mock_client.go
+++ b/test/find_addresses_mock_client.go
@@ -1,0 +1,65 @@
+package test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/nekochans/address-search-apis/infrastructure/repository"
+)
+
+type mockResponse struct {
+	Body       string
+	StatusCode int
+	Result     interface{}
+	Error      error
+}
+
+type successMockClient struct {
+	MockAddress *repository.Address
+}
+
+func (c *successMockClient) Do(req *http.Request) (*http.Response, error) {
+	mockResBodyData := []*repository.Address{c.MockAddress}
+
+	mockResBody := &repository.FindAddressesResponse{
+		Version:   "2021-06-30",
+		Addresses: mockResBodyData,
+	}
+
+	bodyJson, _ := json.Marshal(mockResBody)
+
+	mockRes := &mockResponse{
+		Body:       string(bodyJson),
+		StatusCode: http.StatusOK,
+		Result:     mockResBody,
+	}
+
+	return &http.Response{StatusCode: mockRes.StatusCode, Body: io.NopCloser(strings.NewReader(mockRes.Body))}, nil
+}
+
+func CreateFindAddressesSuccessMockClient(mockAddress *repository.Address) *successMockClient {
+	return &successMockClient{MockAddress: mockAddress}
+}
+
+type errorMockClient struct {
+	StatusCode  int
+	MockResBody interface{}
+}
+
+func (c *errorMockClient) Do(req *http.Request) (*http.Response, error) {
+	bodyJson, _ := json.Marshal(c.MockResBody)
+
+	mockRes := &mockResponse{
+		Body:       string(bodyJson),
+		StatusCode: c.StatusCode,
+		Result:     c.MockResBody,
+	}
+
+	return &http.Response{StatusCode: mockRes.StatusCode, Body: io.NopCloser(strings.NewReader(mockRes.Body))}, nil
+}
+
+func CreateFindAddressesErrorMockClient(statusCode int, mockResBody interface{}) *errorMockClient {
+	return &errorMockClient{StatusCode: statusCode, MockResBody: mockResBody}
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/address-search-apis/issues/12

# Doneの定義
- `net/http` のClientをMock化する為の関数が別のファイルに分離されている事

# 変更点概要
`test` packageを作成して、`KenallAddressRepository` で利用するHTTP通信結果をMock化する為の関数を作成。
